### PR TITLE
Use the new URL for foundry release

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core');
 
-const FOUNDRYVTT_API_URL = 'https://api.foundryvtt.com/_api/packages/release_version/';
+const FOUNDRYVTT_API_URL = 'https://foundryvtt.com/_api/packages/release_version/';
 let manifest = null;
 let manifestPayload = null;
 


### PR DESCRIPTION
Following issues in a delivery, and discussions with Foundry team, we found that the foundry api url has to be updated, the previous one is not updating foundry cache correctly.

https://discord.com/channels/170995199584108546/811676497965613117/1517295329605714161